### PR TITLE
Create Malicious Chrome Extensions

### DIFF
--- a/Malicious Chrome Extensions
+++ b/Malicious Chrome Extensions
@@ -1,0 +1,20 @@
+// Hunting Malicious Chrome Extension
+// A new attack campaign has targeted known Chrome browser extensions, leading to at least 16 extensions being compromised and exposing over 600,000 users to data exposure and credential theft. // https://thehackernews.com/2024/12/16-chrome-extensions-hacked-exposing.html
+// https://www.extensiontotal.com/cyberhaven-incident-live // 11:08 UTC January 1st, 2025 - Total 36 malicious extensions
+
+let MaliciousChromeExtensionID = dynamic(["emedckhdnioeieppmeojgegjfkhdlaeo","eaijffijbobmnonfhilihbejadplhddo","lbneaaedflankmgmfbmaplggbmjjmbae", "hmiaoahjllhfgebflooeeefeiafpkfde"
+,"pdkmmfdfggfpibdjbbghggcllhhainjo","jiofmdifioeejeilfkpegipdjiopiekl", "acmfnomgphggonodopogfbmkneepfgnh","hihblcmlaaademjlakdpicchbjnnnkbo","ndlbedplllcgconngcnfmkadhokfaaln",
+ "bibjgkidgpfbblifamdlkdlhgihmfohh","pkgciiiancapdlpcbppfkmeaieppikkk","epdjhgbipjpbbhoccdeipghoihibnfja", "bbdnohkpnbkdkmnkddobeafboooinpla","befflofjcniongenjmbkgkoljhgliihe",
+ "cedgndijpacnfbdggppddacngjfdkaca", "nnpnnpemnckcfdebeekibpiijlicmpom","dpggmcodlahmljkhlmpgpdcffdaoccni","cplhlgabfijoiabgkigdafklbhhdkahj", "egmennebgadmncfjafcemlecimkepcle",
+ "mnhffkhmpnefgklngfmlndmkimimbphc","oaikpkmjciadfpddlpjjdapglcihgdle", "fbmlcbhdmilaggedifpihjgkkmdgeljh","kkodiihpgodmdankclfibbiphjkfdenh","oeiomhmbaapihbilkfkhmlajkeegnjhe",
+ "igbodamhgjohafcenbcljfegbipdfjpk","bgejafhieobnfpjlpcjjggoboebonfcg","llimhhconnjiflfimocjggfjdlmlhblm", "hodiladlefdpcbemnbbcpclbmknkiaem","epikoohpebngmakjinphfiagogjcnddm",
+ "pajkjnmeojmbapicmbpliphjmcekeaac", "ogbhbgkiojdollpjbhbamafmedkeockb","eanofdhdfbcalhflpbdipkjjkoimeeod","ekpkdmohpdnebfedjjfklhpefgpgaaji", "miglaibdlgminlepgeifekifakochlka",
+ "mbindhfolmpijhodmgkloeeppmkhpmhc","didhgeamncokiaegffipckhhcpnmlcbl", "bibjgkidgpfbblifamdlkdlhgihmfohh","pkgciiiancapdlpcbppfkmeaieppikkk","epdjhgbipjpbbhoccdeipghoihibnfja",
+ "bbdnohkpnbkdkmnkddobeafboooinpla","befflofjcniongenjmbkgkoljhgliihe","cedgndijpacnfbdggppddacngjfdkaca", "nnpnnpemnckcfdebeekibpiijlicmpom","dpggmcodlahmljkhlmpgpdcffdaoccni",
+ "cplhlgabfijoiabgkigdafklbhhdkahj", "egmennebgadmncfjafcemlecimkepcle","mnhffkhmpnefgklngfmlndmkimimbphc","oaikpkmjciadfpddlpjjdapglcihgdle", "fbmlcbhdmilaggedifpihjgkkmdgeljh",
+ "kkodiihpgodmdankclfibbiphjkfdenh","oeiomhmbaapihbilkfkhmlajkeegnjhe", "igbodamhgjohafcenbcljfegbipdfjpk","bgejafhieobnfpjlpcjjggoboebonfcg","llimhhconnjiflfimocjggfjdlmlhblm", 
+ "hodiladlefdpcbemnbbcpclbmknkiaem","epikoohpebngmakjinphfiagogjcnddm","pajkjnmeojmbapicmbpliphjmcekeaac", "ogbhbgkiojdollpjbhbamafmedkeockb","eanofdhdfbcalhflpbdipkjjkoimeeod",
+ "ekpkdmohpdnebfedjjfklhpefgpgaaji", "miglaibdlgminlepgeifekifakochlka","mbindhfolmpijhodmgkloeeppmkhpmhc"]);
+ DeviceFileEvents
+| where ActionType == "FileCreated" and FileName endswith ".crx"
+| where FileName has_any(MaliciousChromeExtensionID)


### PR DESCRIPTION
A new attack campaign has targeted known Chrome browser extensions, leading to at least 16 extensions being compromised and exposing over 600,000 users to data exposure and credential theft. // https://thehackernews.com/2024/12/16-chrome-extensions-hacked-exposing.html
